### PR TITLE
Only use mock or selectors2 if needed (Python < 3.4)

### DIFF
--- a/rfc6555.py
+++ b/rfc6555.py
@@ -16,7 +16,10 @@
 
 import errno
 import socket
-from selectors2 import DefaultSelector, EVENT_WRITE
+try:
+    from selectors  import DefaultSelector, EVENT_WRITE
+except (ImportError, AttributeError):
+    from selectors2 import DefaultSelector, EVENT_WRITE
 
 # time.perf_counter() is defined in Python 3.3
 try:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ if __name__ == '__main__':
           author_email='sethmichaellarson@protonmail.com',
           maintainer='Seth Michael Larson',
           maintainer_email='sethmichaellarson@protonmail.com',
-          install_requires=['selectors2'],
+          install_requires=[
+              'selectors2;python_version<"3.4"'
+          ],
           py_modules=['rfc6555'],
           zip_safe=False,
           classifiers=['Intended Audience :: Developers',

--- a/tests/test_create_connection.py
+++ b/tests/test_create_connection.py
@@ -1,4 +1,8 @@
-import mock
+try:
+    from unittest import mock
+except (ImportError, AttributeError):
+    import mock
+
 import pytest
 import socket
 import rfc6555

--- a/tests/test_ipv6.py
+++ b/tests/test_ipv6.py
@@ -1,6 +1,10 @@
 import socket
-import mock
 import rfc6555
+
+try:
+    from unittest import mock
+except (ImportError, AttributeError):
+    import mock
 
 
 def test_ipv6_available():


### PR DESCRIPTION
Change the code to only need/use selectors 2 if used with a version of python < 3.4