### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.rst
 include LICENSE
 include .coveragerc
+recursive-include tests


### PR DESCRIPTION
Include tests in sdist for packaging systems (FreeBSD ports) that run unittests.
