### PR TITLE
create OSError with arguments

### DIFF
--- a/rfc6555.py
+++ b/rfc6555.py
@@ -16,6 +16,7 @@
 
 import errno
 import socket
+import os
 
 try:
     from selectors import EVENT_WRITE, DefaultSelector
@@ -267,8 +268,7 @@ class _RFC6555ConnectionManager(object):
     def _is_acceptable_errno(self, errno):
         if errno == 0 or errno in _ASYNC_ERRNOS:
             return True
-        self._error = socket.error()
-        self._error.errno = errno
+        self._error = OSError(errno, os.strerror(errno))
         return False
 
     def _is_socket_errored(self, sock):


### PR DESCRIPTION
socket.error is a deprecated alias of OSError since Python 3.3.

Passing no args and setting .errno attribute will make an empty message:

```py
>>> e = socket.error()
>>> e.errno = 2
>>> raise e
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError
```

We need to create the exception like this:

```py
>>> e = OSError(2, os.strerror(2))
>>> raise e
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory
```